### PR TITLE
Change `std::env::var` to `env!`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,8 @@ use tracing_subscriber::{
   self, fmt::format, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
 };
 
+pub static GIT_COMMIT_HASH: &'static str = env!("SAZID_GIT_INFO");
+
 lazy_static! {
   pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase().to_string();
   pub static ref DATA_FOLDER: Option<PathBuf> =
@@ -174,7 +176,7 @@ macro_rules! trace_dbg {
 pub fn version() -> String {
   let author = clap::crate_authors!();
 
-  let commit_hash = GIT_COMMIT_HASH.clone();
+  let commit_hash = GIT_COMMIT_HASH;
 
   // let current_exe_path = PathBuf::from(clap::crate_name!()).display().to_string();
   let config_dir_path = get_config_dir().display().to_string();


### PR DESCRIPTION
`SAZID_GIT_INFO` is a compile time environment variable 

https://github.com/cosmikwolf/sazid/blob/bcdcfbd202d240b3e6915a4d2bce026e741a88d5/build.rs#L49

but `std::env::var` only reads run time values.